### PR TITLE
Updating to add some notes about SELinux.

### DIFF
--- a/community/installation-guides/wings/centos8.md
+++ b/community/installation-guides/wings/centos8.md
@@ -38,3 +38,7 @@ firewall-cmd --reload
 
 ## Installing Wings
 Great, now all of the dependencies and firewall rules have been dealt with. From here follow the [official Wings installation documentation](/wings/1.0/installing.html#enabling-swap).
+
+::: tip
+If you have SELinux enforcement enabled and you are getting AVC denials from your containers, try relocating your Wings data directory from `/var/lib/pterodactyl` to `/var/srv/containers/pterodactyl`. That is where the targeted policy expects Docker to read and write data from.
+:::


### PR DESCRIPTION
While trying to get Wings to work with Fedora CoreOS 34, I started having a *lot* of AVC denials coming from Docker. After looking into the policy and tagging up with some coworkers, I discovered that on Fedora and Fedora-derivatives, including Enterprise Linux, the targeted SELinux policy expects Docker to only read and write data from /var/srv/containers[1] in the context of mounting a directory on the host.

[1] https://github.com/containers/container-selinux/blob/main/container.fc#L137